### PR TITLE
Fix Mageplaza module compatibility

### DIFF
--- a/Model/Service/Logger.php
+++ b/Model/Service/Logger.php
@@ -60,4 +60,14 @@ class Logger implements LoggerInterface
             $this->log($message, Monolog::DEBUG);
         }
     }
+
+    /**
+     * @param string $message
+     */
+    public function error($message)
+    {
+        if ($this->config->isDebugModeEnabled()) {
+            $this->log($message, Monolog::ERROR);
+        }
+    }
 }

--- a/Plugin/Model/Layer/Search/CollectionFilter/ApplyToosoSearch.php
+++ b/Plugin/Model/Layer/Search/CollectionFilter/ApplyToosoSearch.php
@@ -11,10 +11,8 @@ use Bitbull\Tooso\Block\Search\SearchMessageFactory;
 use Magento\Catalog\Model\Category;
 use Magento\Search\Model\QueryFactory;
 use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
-use Magento\Framework\Api\FilterBuilderFactory;
 use Tooso\SDK\Search\Result;
 use Zend_Db_ExprFactory;
-
 
 class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\CollectionFilter
 {
@@ -59,11 +57,6 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
     protected $requestParser;
 
     /**
-     * @var FilterBuilderFactory
-     */
-    private $filterBuilderFactory;
-
-    /**
      * @param QueryFactory $queryFactory
      * @param LoggerInterface $logger
      * @param ConfigInterface $config
@@ -73,7 +66,6 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
      * @param RequestParserInterface $requestParser
      * @param SearchMessageFactory $searchMessageFactory
      * @param Zend_Db_ExprFactory $dbExpressionFactory
-     * @param FilterBuilderFactory $filterBuilderFactory
      */
     public function __construct(
         QueryFactory $queryFactory,
@@ -84,8 +76,7 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
         MessageManagerInterface $messageManage,
         RequestParserInterface $requestParser,
         SearchMessageFactory $searchMessageFactory,
-        Zend_Db_ExprFactory $dbExpressionFactory,
-        FilterBuilderFactory $filterBuilderFactory
+        Zend_Db_ExprFactory $dbExpressionFactory
     )
     {
         parent::__construct($queryFactory);
@@ -97,7 +88,6 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
         $this->requestParser = $requestParser;
         $this->searchMessageFactory = $searchMessageFactory;
         $this->dbExpressionFactory = $dbExpressionFactory;
-        $this->filterBuilderFactory = $filterBuilderFactory;
     }
 
     /**
@@ -111,11 +101,9 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
     ) {
         if ($this->config->isSearchEnabled() !== true) {
             $this->logger->debug('[search plugin] Tooso search is disable, using default Magento search');
+            parent::afterFilter($subject, $result, $collection, $category);
             return;
         }
-
-        // Hard clean filters
-        $collection->setFilterBuilder($this->filterBuilderFactory->create());
 
         /** @var \Magento\Search\Model\Query $query */
         $query = $this->queryFactory->get();

--- a/Plugin/Model/Layer/Search/CollectionFilter/ApplyToosoSearch.php
+++ b/Plugin/Model/Layer/Search/CollectionFilter/ApplyToosoSearch.php
@@ -11,8 +11,10 @@ use Bitbull\Tooso\Block\Search\SearchMessageFactory;
 use Magento\Catalog\Model\Category;
 use Magento\Search\Model\QueryFactory;
 use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Framework\Api\FilterBuilderFactory;
 use Tooso\SDK\Search\Result;
 use Zend_Db_ExprFactory;
+
 
 class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\CollectionFilter
 {
@@ -57,6 +59,11 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
     protected $requestParser;
 
     /**
+     * @var FilterBuilderFactory
+     */
+    private $filterBuilderFactory;
+
+    /**
      * @param QueryFactory $queryFactory
      * @param LoggerInterface $logger
      * @param ConfigInterface $config
@@ -66,6 +73,7 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
      * @param RequestParserInterface $requestParser
      * @param SearchMessageFactory $searchMessageFactory
      * @param Zend_Db_ExprFactory $dbExpressionFactory
+     * @param FilterBuilderFactory $filterBuilderFactory
      */
     public function __construct(
         QueryFactory $queryFactory,
@@ -76,7 +84,8 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
         MessageManagerInterface $messageManage,
         RequestParserInterface $requestParser,
         SearchMessageFactory $searchMessageFactory,
-        Zend_Db_ExprFactory $dbExpressionFactory
+        Zend_Db_ExprFactory $dbExpressionFactory,
+        FilterBuilderFactory $filterBuilderFactory
     )
     {
         parent::__construct($queryFactory);
@@ -88,6 +97,7 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
         $this->requestParser = $requestParser;
         $this->searchMessageFactory = $searchMessageFactory;
         $this->dbExpressionFactory = $dbExpressionFactory;
+        $this->filterBuilderFactory = $filterBuilderFactory;
     }
 
     /**
@@ -101,9 +111,11 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
     ) {
         if ($this->config->isSearchEnabled() !== true) {
             $this->logger->debug('[search plugin] Tooso search is disable, using default Magento search');
-            parent::afterFilter($subject, $result, $collection, $category);
             return;
         }
+
+        // Hard clean filters
+        $collection->setFilterBuilder($this->filterBuilderFactory->create());
 
         /** @var \Magento\Search\Model\Query $query */
         $query = $this->queryFactory->get();

--- a/Plugin/Model/Layer/Search/CollectionFilter/ApplyToosoSearch.php
+++ b/Plugin/Model/Layer/Search/CollectionFilter/ApplyToosoSearch.php
@@ -167,6 +167,17 @@ class ApplyToosoSearch extends \Magento\CatalogSearch\Model\Layer\Search\Plugin\
                         return $product['product_id'];
                     }, $this->search->getProducts());
 
+
+                    if (sizeof($products) === 0) {
+                        $this->logger->error('[search plugin] No product found with SKU response, check products with SKUs: '.implode(',', $searchResult->getResults()));
+                        if ($this->search->isFallbackEnable()) {
+                            $collection->addSearchFilter($queryText);
+                            $this->logger->debug('[search plugin] Executing Magento search fallback');
+                            return;
+                        }
+                        return;
+                    }
+
                     $this->logger->debug('[search plugin] Filter entity_id with ids: '.implode(',', $products));
                     $collection->addFieldToFilter('entity_id', $products);
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,7 +16,7 @@
     </type>
 
     <type name="Magento\Catalog\Model\Layer\Search\CollectionFilter">
-        <plugin name="searchQuery" type="Magento\CatalogSearch\Model\Layer\Search\Plugin\CollectionFilter" disabled="false" />
+        <plugin name="searchQuery" type="Magento\CatalogSearch\Model\Layer\Search\Plugin\CollectionFilter" disabled="true" />
         <plugin name="searchQueryTooso" type="Bitbull\Tooso\Plugin\Model\Layer\Search\CollectionFilter\ApplyToosoSearch" />
     </type>
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,7 +16,7 @@
     </type>
 
     <type name="Magento\Catalog\Model\Layer\Search\CollectionFilter">
-        <plugin name="searchQuery" type="Magento\CatalogSearch\Model\Layer\Search\Plugin\CollectionFilter" disabled="true" />
+        <plugin name="searchQuery" type="Magento\CatalogSearch\Model\Layer\Search\Plugin\CollectionFilter" disabled="false" />
         <plugin name="searchQueryTooso" type="Bitbull\Tooso\Plugin\Model\Layer\Search\CollectionFilter\ApplyToosoSearch" />
     </type>
 

--- a/etc/search_request.xml
+++ b/etc/search_request.xml
@@ -8,16 +8,107 @@
 <requests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="urn:magento:framework:Search/etc/search_request.xsd">
     <request query="quick_search_container" index="catalogsearch_fulltext">
+        <dimensions>
+            <dimension name="scope" value="default"/>
+        </dimensions>
         <queries>
             <query xsi:type="boolQuery" name="quick_search_container" boost="1">
+                <queryReference clause="should" ref="search" />
+                <queryReference clause="must" ref="category"/>
+                <queryReference clause="must" ref="price"/>
+                <queryReference clause="must" ref="visibility"/>
                 <queryReference clause="should" ref="entity_id"/>
+            </query>
+            <query xsi:type="matchQuery" value="$search_term$" name="search">
+                <match field="sku"/>
+                <match field="*"/>
+            </query>
+            <query xsi:type="filteredQuery" name="category">
+                <filterReference clause="must" ref="category_filter"/>
+            </query>
+            <query xsi:type="filteredQuery" name="price">
+                <filterReference clause="must" ref="price_filter"/>
+            </query>
+            <query xsi:type="filteredQuery" name="visibility">
+                <filterReference clause="must" ref="visibility_filter"/>
             </query>
             <query xsi:type="filteredQuery" name="entity_id">
                 <filterReference clause="should" ref="entity_id"/>
             </query>
         </queries>
         <filters>
+            <filter xsi:type="termFilter" name="category_filter" field="category_ids" value="$category_ids$"/>
+            <filter xsi:type="rangeFilter" name="price_filter" field="price" from="$price.from$" to="$price.to$"/>
+            <filter xsi:type="termFilter" name="visibility_filter" field="visibility" value="$visibility$"/>
             <filter xsi:type="termFilter" name="entity_id" field="entity_id" value="$entity_id$"/>
+        </filters>
+        <aggregations>
+            <bucket name="price_bucket" field="price" xsi:type="dynamicBucket" method="$price_dynamic_algorithm$">
+                <metrics>
+                    <metric type="count"/>
+                </metrics>
+            </bucket>
+            <bucket name="category_bucket" field="category_ids" xsi:type="termBucket">
+                <metrics>
+                    <metric type="count"/>
+                </metrics>
+            </bucket>
+        </aggregations>
+        <from>0</from>
+        <size>10000</size>
+    </request>
+    <request query="advanced_search_container" index="catalogsearch_fulltext">
+        <dimensions>
+            <dimension name="scope" value="default"/>
+        </dimensions>
+        <queries>
+            <query xsi:type="boolQuery" name="advanced_search_container" boost="1">
+                <queryReference clause="should" ref="sku_query"/>
+                <queryReference clause="should" ref="price_query"/>
+                <queryReference clause="should" ref="category_query"/>
+            </query>
+            <query name="sku_query" xsi:type="filteredQuery">
+                <filterReference clause="must" ref="sku_query_filter"/>
+            </query>
+            <query name="price_query" xsi:type="filteredQuery">
+                <filterReference clause="must" ref="price_query_filter"/>
+            </query>
+            <query name="category_query" xsi:type="filteredQuery">
+                <filterReference clause="must" ref="category_filter"/>
+            </query>
+        </queries>
+        <filters>
+            <filter xsi:type="wildcardFilter" name="sku_query_filter" field="sku" value="$sku$"/>
+            <filter xsi:type="rangeFilter" name="price_query_filter" field="price" from="$price.from$" to="$price.to$"/>
+            <filter xsi:type="termFilter" name="category_filter" field="category_ids" value="$category_ids$"/>
+        </filters>
+        <from>0</from>
+        <size>10000</size>
+    </request>
+    <request query="catalog_view_container" index="catalogsearch_fulltext">
+        <dimensions>
+            <dimension name="scope" value="default"/>
+        </dimensions>
+        <queries>
+            <query xsi:type="boolQuery" name="catalog_view_container" boost="1">
+                <queryReference clause="must" ref="category"/>
+                <queryReference clause="must" ref="price"/>
+                <queryReference clause="must" ref="visibility"/>
+            </query>
+            <query xsi:type="filteredQuery" name="category">
+                <filterReference clause="must" ref="category_filter"/>
+            </query>
+            <query xsi:type="filteredQuery" name="price">
+                <filterReference clause="must" ref="price_filter"/>
+            </query>
+            <query xsi:type="filteredQuery" name="visibility">
+                <filterReference clause="must" ref="visibility_filter"/>
+            </query>
+        </queries>
+        <filters>
+            <filter xsi:type="termFilter" name="category_filter" field="category_ids" value="$category_ids$"/>
+            <filter xsi:type="rangeFilter" name="price_filter" field="price" from="$price.from$" to="$price.to$"/>
+            <filter xsi:type="termFilter" name="visibility_filter" field="visibility" value="$visibility$"/>
         </filters>
         <aggregations>
             <bucket name="price_bucket" field="price" xsi:type="dynamicBucket" method="$price_dynamic_algorithm$">

--- a/etc/search_request.xml
+++ b/etc/search_request.xml
@@ -19,5 +19,19 @@
         <filters>
             <filter xsi:type="termFilter" name="entity_id" field="entity_id" value="$entity_id$"/>
         </filters>
+        <aggregations>
+            <bucket name="price_bucket" field="price" xsi:type="dynamicBucket" method="$price_dynamic_algorithm$">
+                <metrics>
+                    <metric type="count"/>
+                </metrics>
+            </bucket>
+            <bucket name="category_bucket" field="category_ids" xsi:type="termBucket">
+                <metrics>
+                    <metric type="count"/>
+                </metrics>
+            </bucket>
+        </aggregations>
+        <from>0</from>
+        <size>10000</size>
     </request>
 </requests>


### PR DESCRIPTION
When this plugin is installed aside Mageplaza_LayeredNavigation these error is showed up:
```
Exception #0 (Magento\Framework\Exception\LocalizedException): Invalid XML in file /var/www/html/vendor/bitbull/magento-2-tooso-search/etc/search_request.xml:
Element 'request': Missing child element(s). Expected is one of ( aggregations, from ).
Line: 10
```
```
Exception #0 (Magento\Framework\Exception\LocalizedException): Invalid XML in file /var/www/html/vendor/bitbull/magento-2-tooso-search/etc/search_request.xml:
Element 'aggregations': Missing child element(s). Expected is ( bucket ).
Line: 22
```
when file `etc/search_request.xml` is fixed
```
1 exception(s):
Exception #0 (Magento\Framework\Exception\LocalizedException): Sorry, something went wrong. You can find out more in the error log.
```
going deep with xdebug seems error comes from a block render. Re-enabling the `Magento\CatalogSearch\Model\Layer\Search\Plugin\CollectionFilter` plugin it start working without errors.